### PR TITLE
install and run ansible on the vm 

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,22 +4,16 @@ Vagrant.configure("2") do |config|
   config.vm.box = "trusty64-current"
   config.vm.box_url = "https://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-amd64-vagrant-disk1.box"
   config.vm.synced_folder ".", "/vagrant", nfs: true
-  config.ssh.forward_agent = true
   config.vm.provider :virtualbox do |vb|
     vb.customize ["modifyvm", :id, "--memory", "1024"]
   end
   config.vm.define "dev", primary: true do |dev|
-    config.vm.network "private_network", ip: "172.16.10.15"
     # nginx
     config.vm.network :forwarded_port, guest: 80, host: 9080
     config.vm.network :forwarded_port, guest: 5000, host: 5001
     config.vm.network :forwarded_port, guest: 5432, host: 5433
-    config.vm.provision "ansible" do |ansible|
-      ansible.host_key_checking = false
-      ansible.extra_vars = { ansible_ssh_user: 'vagrant' }
-      ansible.playbook = "provisioning/playbook.yml"
-      ansible.inventory_path = "provisioning/development"
-      ansible.limit = "all"
-    end
-  end
+    config.vm.provision :shell,
+      :keep_color => true,
+      :path => "setup.sh"
+   end
 end

--- a/provisioning/development
+++ b/provisioning/development
@@ -1,2 +1,2 @@
 [development]
-172.16.10.15
+localhost ansible_connection=local

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+export PYTHONUNBUFFERED=1
+export ANSIBLE_FORCE_COLOR=1
+
+if [ $(dpkg-query -W -f='${Status}' ansible 2>/dev/null | grep -c "ok installed") -eq 0 ];
+then
+    echo "Add APT repositories"
+    export DEBIAN_FRONTEND=noninteractive
+    apt-get install -qq software-properties-common &> /dev/null || exit 1
+    apt-add-repository ppa:ansible/ansible &> /dev/null || exit 1
+
+    apt-get update -qq
+
+    echo "Installing Ansible"
+    apt-get install -qq ansible &> /dev/null || exit 1
+    echo "Ansible installed"
+fi
+
+cd /vagrant/provisioning
+#move ansible inventory hosts file into  default location
+mkdir -p /etc/ansible/
+cp development /etc/ansible/development
+#undo executable bits on synced files since ansible gets grumpy
+chmod -X /etc/ansible/development
+ansible-playbook -i /etc/ansible/development playbook.yml -vv
+  


### PR DESCRIPTION
Installing and running ansible on the guest vm makes it easier to control correct ansible version etc. It also theoretically allows windows machines as vm hosts.

However, the file sharing options for virtualbox on windows are not very good, creating problems when trying to install python virtual environments on the /vagrant shared folder. Possible options are: moving virtual environment setup away from /vagrant or using symlinks to the folders that need to be updatable. 
